### PR TITLE
Fix agencies result default avatar

### DIFF
--- a/src/Components/AgenciesSearch/AgenciesResults.js
+++ b/src/Components/AgenciesSearch/AgenciesResults.js
@@ -33,11 +33,30 @@ export default function AgenciesResults(props) {
         result.description = result.description.slice(0, 150).concat('...');
       }
 
+      if (!result.image_url) {
+        switch (result.type) {
+          case 'Government':
+            result.avatar = "🏛️";
+            break;
+          case 'Commercial':
+            result.avatar = "🏢";
+            break;
+          case 'Multinational':
+            result.avatar = "🏢";
+            break;
+          default:
+            result.avatar = "🏢";
+            break;
+        }
+      }
+
       return(
         <div>
           <ListItem alignItems="flex-start">
             <ListItemAvatar>
-              <Avatar variant='rounded' alt={result.abbrev} src={result.image_url} />
+              <Avatar variant='rounded' alt={result.abbrev} src={result.image_url}>
+                {result.avatar}
+              </Avatar>
             </ListItemAvatar>
             <ListItemText
               primary={result.name}


### PR DESCRIPTION
Fixes #3 
1. Added the avatar property to result objects that do not include an image_url.
2. Assigned the appropriate emoji/icon to the avatar property of the result based on the type property.
3. In the returned JSX, the result.avatar is assigned as the child node of the Avatar component.
